### PR TITLE
Fixes  Class::MOP::load_class deprecation warning

### DIFF
--- a/lib/Catalyst/Helper/Controller/DBIC/API/REST.pm
+++ b/lib/Catalyst/Helper/Controller/DBIC/API/REST.pm
@@ -1,5 +1,6 @@
 package Catalyst::Helper::Controller::DBIC::API::REST;
 
+use Class::Load;
 use namespace::autoclean;
 
 use strict;
@@ -200,7 +201,7 @@ sub mk_compclass {
     $helper->{appprefix} = Catalyst::Utils::appprefix( $helper->{name} );
 
     ## Connect to schema for class info
-    Class::MOP::load_class($schema_class);
+    Class::Load::load_class($schema_class);
     my $schema = $schema_class->connect;
 
     my $path_app = File::Spec->catdir( $FindBin::Bin, "..", "lib",


### PR DESCRIPTION
Hey,

This pull request fixes the Class::MOP::load_class deprecation warning.

Here's a blurb the Moose folks were distributing:

---

We recently deprecated Class::MOP::load_class in Moose. It appears that your module is affected. You can read more about the change here: https://metacpan.org/pod/release/ETHER/Moose-2.1106-TRIAL/lib/Moose/Manual/Delta.pod#pod2.1200 We recommend that you take a look at your code to see if it indeed does need to be updated with respect to the latest Moose release, 2.1106-TRIAL. If you have any questions, then please ask either on Moose mailing list : http://lists.perl.org/list/moose.html or on #moose & #moose-dev on irc.perl.org.
